### PR TITLE
Correction of an error in the destruction of the carousel

### DIFF
--- a/src/jquery.jcarousellite.js
+++ b/src/jquery.jcarousellite.js
@@ -431,7 +431,7 @@ $.fn.jCarouselLite = function(options) {
         o.$btnNext.addClass(o.btnDisabledClass).unbind('.jc');
       }
       if (o.btnGo) {
-        $.each(o.btnGo, function(i, val) {
+        $.each($(o.btnGo), function(i, val) {
           $(val).unbind('.jc');
         });
       }


### PR DESCRIPTION
Hi it seems that there is a bug when removing event listeners from 'btnGo'

In this case: 
`$.each(o.btnGo, function(i, val) {`
The 'each' method will iterate over a string variable, that contains class names, but not jquery objects..

and
`$(val).unbind('.jc');`
 will produce error.
